### PR TITLE
Correct misspelling of architectures field name

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -6,4 +6,4 @@ sentence=Nordic nRF24L01(+) register read/write library for Arduino
 paragraph=This is a low-level nRF24L01(+) library to read and write registers by using a SPI interface.
 category=Communication
 url=https://github.com/Erriez/ArduinoLibraryNRF24L01Iface
-architecture=*
+architectures=*


### PR DESCRIPTION
The correct spelling of the field name is architectures, not architecture.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#libraryproperties-file-format